### PR TITLE
Fix memory consumption of custom plan

### DIFF
--- a/graphile.config.mjs
+++ b/graphile.config.mjs
@@ -12,6 +12,9 @@ const preset = {
         "postgres://postgres:mysecretpassword1@localhost:5432/grafast_repro",
     }),
   ],
+  grafast: {
+    explain: true
+  },
   grafserv: { watch: true },
   plugins: [MyPlugin],
 };


### PR DESCRIPTION
Your plugin previously instructed Grafast:

For each user:
1. Build a step representing fetching all the languages from the DB (`select ... from languages`) _(this gets hoisted because Grafast realises that it's not dependent on the user at all, so we just fetch it once)_
2. Fetch the `language` attribute for each row (`select language from languages`)
3. Apply the transform because we want to deal with these objects in the next step _(unfortunately because this is a subroutine it has to happen in the current layer, which is inside the user object, so for each and every user returned by the result, we are creating a new array and NUMBER_OF_LANGUAGES new objects; resulting in `NUMBER_OF_USERS * (NUMBER_OF_LANGUAGES + 1)` new objects in JS memory, at a minimum)_
4. For each of these arrays of objects, find the length.

You're creating 1000 users * 1000 languages = 1million JS objects. Assuming each JS object is about 40 bytes, that's about 40MB of RAM on its own. Not sure why it's spiking to 250MB but probably something along these lines.

I've rewritten your plan to use aggregation and to not use any transforms, this results in just one SQL query (rather than 2) and significantly lower memory usage.